### PR TITLE
[Feat] feature/#95 채팅방 반응형 ui 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,95 +1,99 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { PAGE_PATH } from './constants/path';
 import {
-  AlertMainPage,
-  CalenderMainPage,
-  ChatMainPage,
-  FamilyMainPage,
-  LandingPage,
-  LoginPage,
-  MainPage,
-  PhotoMainPage,
-  ServiceMainPage,
-  SignupPage,
-  FamilySpaceSettings,
-  FamilySettings,
-  EditProfile,
+	AlertMainPage,
+	CalenderMainPage,
+	ChatMainPage,
+	FamilyMainPage,
+	LandingPage,
+	LoginPage,
+	MainPage,
+	PhotoMainPage,
+	ServiceMainPage,
+	SignupPage,
+	FamilySpaceSettings,
+	FamilySettings,
+	EditProfile,
+	ChatMessagePage,
 } from './pages';
 
 import { AuthLayout, HomeLayout } from './layout';
-import { ErrorBoundaryProvider } from './container/ErrorBoundaryProvider.jsx';
 
 const router = createBrowserRouter([
-  {
-    path: `${PAGE_PATH.BASE}`,
-    element: <AuthLayout />,
-    children: [
-      {
-        index: true,
-        element: <LandingPage />,
-      },
-      {
-        path: `${PAGE_PATH.LOGIN}`,
-        element: <LoginPage />,
-      },
-      {
-        path: `${PAGE_PATH.SIGN_UP}`,
-        element: <SignupPage />,
-      },
-      {
-        path: `${PAGE_PATH.SERVICE}`,
-        element: <ServiceMainPage />,
-      },
-    ],
-  },
-  {
-    path: `${PAGE_PATH.HOME}`,
-    element: <HomeLayout />,
-    children: [
-      {
-        index: true,
-        element: <MainPage />,
-      },
-      {
-        path: `${PAGE_PATH.ALERT}`,
-        element: <AlertMainPage />,
-      },
-      {
-        path: `${PAGE_PATH.CALENDER}`,
-        element: <CalenderMainPage />,
-      },
-      {
-        path: `${PAGE_PATH.CHAT}`,
-        element: <ChatMainPage />,
-      },
-      {
-        path: `${PAGE_PATH.FAMILY}`,
-        element: <FamilyMainPage />,
-      },
-      {
-        path: `${PAGE_PATH.PHOTO}`,
-        element: <PhotoMainPage />,
-      },
-      {
-        path: `${PAGE_PATH.SETTING}/*`,
-        children: [
-          {
-            path: `${PAGE_PATH.FAMILY_SPACE_SETTINGS}`,
-            element: <FamilySpaceSettings />,
-          },
-          { path: `${PAGE_PATH.EDIT_PROFILE}`, element: <EditProfile /> },
-          {
-            path: `${PAGE_PATH.FAMILY_SETTINGS}`,
-            element: <FamilySettings />,
-          },
-        ],
-      },
-    ],
-  },
+	{
+		path: `${PAGE_PATH.BASE}`,
+		element: <AuthLayout />,
+		children: [
+			{
+				index: true,
+				element: <LandingPage />,
+			},
+			{
+				path: `${PAGE_PATH.LOGIN}`,
+				element: <LoginPage />,
+			},
+			{
+				path: `${PAGE_PATH.SIGN_UP}`,
+				element: <SignupPage />,
+			},
+			{
+				path: `${PAGE_PATH.SERVICE}`,
+				element: <ServiceMainPage />,
+			},
+		],
+	},
+	{
+		path: `${PAGE_PATH.HOME}`,
+		element: <HomeLayout />,
+		children: [
+			{
+				index: true,
+				element: <MainPage />,
+			},
+			{
+				path: `${PAGE_PATH.ALERT}`,
+				element: <AlertMainPage />,
+			},
+			{
+				path: `${PAGE_PATH.CALENDER}`,
+				element: <CalenderMainPage />,
+			},
+			{
+				path: `${PAGE_PATH.CHAT}`,
+				element: <ChatMainPage />,
+			},
+			{
+				path: `${PAGE_PATH.FAMILY}`,
+				element: <FamilyMainPage />,
+			},
+			{
+				path: `${PAGE_PATH.PHOTO}`,
+				element: <PhotoMainPage />,
+			},
+			{
+				path: `${PAGE_PATH.SETTING}/*`,
+				children: [
+					{
+						path: `${PAGE_PATH.FAMILY_SPACE_SETTINGS}`,
+						element: <FamilySpaceSettings />,
+					},
+					{ path: `${PAGE_PATH.EDIT_PROFILE}`, element: <EditProfile /> },
+					{
+						path: `${PAGE_PATH.FAMILY_SETTINGS}`,
+						element: <FamilySettings />,
+					},
+				],
+			},
+			{
+				path: `${PAGE_PATH.CHAT}/${PAGE_PATH.CHAT_MESSAGE}/:chatRoomId`,
+				element: <ChatMessagePage />,
+			},
+		],
+	},
 ]);
 
 function App() {
-  return <RouterProvider router={router} />;
+	return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/components/chat/chatbar/Chatbar.jsx
+++ b/src/components/chat/chatbar/Chatbar.jsx
@@ -73,17 +73,20 @@ const Chatbar = () => {
 
 	return (
 		<S.Container>
-			<S.ButtonContainer>
-				<S.Button onClick={chatDropdownOpen}>
-					<p>새로 만들기</p>
-					<IoIosArrowDown />
-				</S.Button>
-				<S.CreateBox $open={chatDropdown}>
-					<li onClick={onClick}>일반 채팅방</li>
-					{familyData && <Modal members={familyData.familyDataList} />}
-					<li onClick={creatGroupChatRoom}>가족 단체 채팅방</li>
-				</S.CreateBox>
-			</S.ButtonContainer>
+			<S.HeaderContaienr>
+				<h1>채팅</h1>
+				<S.ButtonContainer>
+					<S.Button onClick={chatDropdownOpen}>
+						<p>새로 만들기</p>
+						<IoIosArrowDown />
+					</S.Button>
+					<S.CreateBox $open={chatDropdown}>
+						<li onClick={onClick}>일반 채팅방</li>
+						{familyData && <Modal members={familyData.familyDataList} />}
+						<li onClick={creatGroupChatRoom}>가족 단체 채팅방</li>
+					</S.CreateBox>
+				</S.ButtonContainer>
+			</S.HeaderContaienr>
 			<S.Search>
 				<input type="text" placeholder="메시지방, 메시지 검색" />
 				<CiSearch size={20} />

--- a/src/components/chat/chatbar/Chatbar.style.js
+++ b/src/components/chat/chatbar/Chatbar.style.js
@@ -10,11 +10,19 @@ const Container = styled.div`
 	align-items: center;
 	background-color: ${theme.COLOR.BACKGROUND.WHITE};
 	box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.05);
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		width: 100%;
+	}
 `;
 
 const ButtonContainer = styled.div`
 	position: relative;
 	${theme.ALIGN.COLUMN_CENTER};
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		width: 70%;
+	}
 `;
 
 const CreateBox = styled.div`
@@ -38,6 +46,10 @@ const CreateBox = styled.div`
 			background-color: ${theme.COLOR.GRAY.GRAY_50};
 		}
 	}
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		width: 100%;
+	}
 `;
 
 const Button = styled.button`
@@ -49,12 +61,18 @@ const Button = styled.button`
 	font-weight: bold;
 	border-radius: 10px;
 	${theme.ALIGN.ROW_CENTER};
+	color: ${theme.COLOR.COMMON.BLACK};
+
 	p {
 		margin-right: 5px;
 		font-size: ${FONT_SIZE.SM};
 	}
 	&:hover {
 		cursor: pointer;
+	}
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		width: 100%;
 	}
 `;
 
@@ -80,6 +98,45 @@ const Search = styled.div`
 			color: ${theme.COLOR.GRAY.GRAY_350};
 		}
 	}
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		display: none;
+	}
 `;
 
-export { Container, ButtonContainer, CreateBox, Button, Search };
+const HeaderContaienr = styled.div`
+	${theme.ALIGN.ROW_CENTER};
+
+	h1 {
+		display: none;
+	}
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		width: 100%;
+		padding-right: 50px;
+		margin-bottom: 40px;
+
+		h1 {
+			display: block;
+			width: 80px;
+			margin-top: 30px;
+			${theme.ALIGN.ROW_CENTER};
+			font-size: ${FONT_SIZE.TWO_XL};
+		}
+	}
+
+	@media ${theme.WINDOW_SIZE.MOBILE} {
+		h1 {
+			font-size: ${FONT_SIZE.XL};
+		}
+	}
+`;
+
+export {
+	Container,
+	ButtonContainer,
+	CreateBox,
+	Button,
+	Search,
+	HeaderContaienr,
+};

--- a/src/components/chat/chatroom/ChatRoom.jsx
+++ b/src/components/chat/chatroom/ChatRoom.jsx
@@ -2,13 +2,22 @@ import { useChatRoom } from '../../../store';
 import Avatar from '../../common/avatar/Avatar';
 import * as S from './ChatRoom.style';
 import useGetRealImageUrl from '../../../hooks/queries/image/useGetRealImage';
+import { useNavigate } from 'react-router-dom';
+import { PAGE_PATH } from '../../../constants';
 
 const ChatRoom = ({ room }) => {
+	const navigation = useNavigate();
 	const { setChatRoom } = useChatRoom();
 	const { chatRoomId, title, imageUrl } = room;
 
 	const handleClick = () => {
 		setChatRoom({ chatRoomId, chatTitle: title, chatImg: imageUrl });
+
+		if (window.innerWidth < 1024) {
+			navigation(
+				`${PAGE_PATH.HOME}/${PAGE_PATH.CHAT}/${PAGE_PATH.CHAT_MESSAGE}/${chatRoomId}`,
+			);
+		}
 	};
 
 	const { data, isPending } = useGetRealImageUrl({ imageUrl, chatRoomId });

--- a/src/components/chat/chatroom/ChatRoom.style.js
+++ b/src/components/chat/chatroom/ChatRoom.style.js
@@ -15,6 +15,10 @@ const Container = styled.div`
 		background-color: ${theme.COLOR.COMMON.WHITE};
 		border-radius: 15px;
 	}
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		width: 90%;
+	}
 `;
 
 const UserContainer = styled.div`

--- a/src/components/chat/message/Message.jsx
+++ b/src/components/chat/message/Message.jsx
@@ -13,8 +13,15 @@ import theme from '../../../theme/theme';
 import useModal from '../../../hooks/useModal';
 import { ChangeRoom, Alert, PopOver } from '../../';
 import useGetRealImageUrl from '../../../hooks/queries/image/useGetRealImage.js';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { PAGE_PATH } from '../../../constants';
+import { IoIosArrowBack } from 'react-icons/io';
 
 const Message = () => {
+	const { pathname } = useLocation();
+	const nav = useNavigate();
+	const mobile = pathname.includes(`${PAGE_PATH.CHAT_MESSAGE}`);
+
 	const { chatTitle, chatImg, chatRoomId, changeRoomInfo, setChangeRoomInfo } =
 		useChatRoom();
 	const [open, setOpen] = useState();
@@ -66,7 +73,7 @@ const Message = () => {
 			);
 		} else {
 			return (
-				<S.Container>
+				<S.Container $mobile={mobile}>
 					<Alert
 						isOpen={isOpen}
 						message="채팅방을 나가시겠습니까?"
@@ -75,6 +82,7 @@ const Message = () => {
 					/>
 					<S.NavContainer>
 						<S.UserContainer>
+							{mobile && <IoIosArrowBack size={25} onClick={() => nav(-1)} />}
 							<img src={data?.result.url} alt="profile" />
 							<p>{chatTitle}</p>
 						</S.UserContainer>
@@ -85,15 +93,19 @@ const Message = () => {
 							</S.PopoverWrapper>
 						</S.Menu>
 					</S.NavContainer>
-
-					<S.InputContainer>
-						<S.IconWrapper>
-							<HiOutlinePhotograph size={25} />
-							<FaRegSmile size={23} />
-						</S.IconWrapper>
-						<input placeholder="메시지를 입력해주세요. (Enter: 전송 / Shift + Enter: 줄바꿈)" />
-						<FiSend size={25} />
-					</S.InputContainer>
+					<S.MessageContainer>
+						<S.test>여기에 내용</S.test>
+					</S.MessageContainer>
+					<S.SendContainer>
+						<S.InputContainer>
+							<S.IconWrapper>
+								<HiOutlinePhotograph size={25} />
+								<FaRegSmile size={23} />
+							</S.IconWrapper>
+							<input placeholder="메시지를 입력해주세요. (Enter: 전송 / Shift + Enter: 줄바꿈)" />
+							<FiSend size={25} />
+						</S.InputContainer>
+					</S.SendContainer>
 				</S.Container>
 			);
 		}

--- a/src/components/chat/message/Message.style.js
+++ b/src/components/chat/message/Message.style.js
@@ -4,6 +4,10 @@ import theme from '../../../theme/theme';
 const Container = styled.div`
 	flex: 1;
 	${theme.ALIGN.COLUMN_SPACE_BETWEEN};
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		display: none;
+	}
 `;
 
 const InputContainer = styled.div`
@@ -89,6 +93,10 @@ const NoChatContainer = styled.div`
 	flex: 1;
 	p {
 		margin-top: 10px;
+	}
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		display: none;
 	}
 `;
 

--- a/src/components/chat/message/Message.style.js
+++ b/src/components/chat/message/Message.style.js
@@ -2,11 +2,18 @@ import styled from 'styled-components';
 import theme from '../../../theme/theme';
 
 const Container = styled.div`
+	position: relative;
 	flex: 1;
-	${theme.ALIGN.COLUMN_SPACE_BETWEEN};
+	height: 100vh;
+
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
 
 	@media ${theme.WINDOW_SIZE.PC} {
-		display: none;
+		display: ${props => (props.$mobile ? 'flex' : 'none')};
+		height: 100%;
+		width: 100%;
 	}
 `;
 
@@ -17,7 +24,7 @@ const InputContainer = styled.div`
 	height: 60px;
 	background-color: ${theme.COLOR.GRAY.GRAY_0};
 	border-radius: 20px;
-	margin-bottom: 30px;
+
 	input {
 		border: none;
 		background-color: inherit;
@@ -36,6 +43,7 @@ const InputContainer = styled.div`
 
 const IconWrapper = styled.div`
 	${theme.ALIGN.ROW_CENTER};
+	margin-right: 5px;
 	svg {
 		margin-left: 15px;
 		margin-right: 0;
@@ -66,6 +74,11 @@ const UserContainer = styled.div`
 	p {
 		font-size: 20px;
 		font-weight: 700;
+	}
+
+	svg {
+		cursor: pointer;
+		margin-right: 20px;
 	}
 `;
 
@@ -100,6 +113,30 @@ const NoChatContainer = styled.div`
 	}
 `;
 
+const SendContainer = styled.div`
+	${theme.ALIGN.COLUMN_CENTER};
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	margin-bottom: 10px;
+`;
+
+const MessageContainer = styled.div`
+	${theme.ALIGN.COLUMN_CENTER};
+	width: 100%;
+	height: calc(100% - 120px);
+	margin-bottom: 40px;
+	padding: 0 20px;
+`;
+
+const test = styled.div`
+	width: 100%;
+	height: 100%;
+	overflow-y: auto;
+	margin-bottom: 60px;
+	overflow-x: hidden;
+`;
+
 export {
 	InputContainer,
 	IconWrapper,
@@ -109,4 +146,7 @@ export {
 	Menu,
 	PopoverWrapper,
 	NoChatContainer,
+	SendContainer,
+	MessageContainer,
+	test,
 };

--- a/src/components/common/sidebar/SideBar.jsx
+++ b/src/components/common/sidebar/SideBar.jsx
@@ -16,9 +16,12 @@ import MORE from '../../../assets/images/moreBox.svg';
 const Sidebar = () => {
 	const { pathname } = useLocation();
 	const nav = useNavigate();
+	const noDisplay = pathname.startsWith(
+		`${PAGE_PATH.HOME}/${PAGE_PATH.CHAT}/${PAGE_PATH.CHAT_MESSAGE}`,
+	);
 
 	return (
-		<S.Container>
+		<S.Container $noDisplay={noDisplay}>
 			<S.Logo src={LOGO} />
 			<S.NavContainer>
 				<Link

--- a/src/components/common/sidebar/SideBar.style.js
+++ b/src/components/common/sidebar/SideBar.style.js
@@ -20,6 +20,10 @@ const Container = styled.div`
 		width: 100%;
 		height: 80px;
 	}
+
+	@media ${theme.WINDOW_SIZE.PC} {
+		display: ${({ $noDisplay }) => ($noDisplay ? 'none' : 'flex')};
+	}
 `;
 
 const Logo = styled.img`

--- a/src/constants/path.js
+++ b/src/constants/path.js
@@ -1,49 +1,50 @@
 const PAGE_PATH = {
-  // post
-  BASE: '/',
-  HOME: '/home',
-  // Login
-  LOGIN: 'login',
-  // Signup
-  SIGN_UP: 'signup',
-  // Service
-  SERVICE: 'service',
-  // Chat
-  CHAT: 'chat',
-  // Setting
-  SETTING: 'setting',
-  // Photo
-  PHOTO: 'photo',
-  // Calender
-  CALENDER: 'calender',
-  // Alert
-  ALERT: 'alert',
-  // Family
-  FAMILY: 'family',
-  // setting/family-space-settings
-  FAMILY_SPACE_SETTINGS: 'family-space-settings',
-  // setting/edit-profile
-  EDIT_PROFILE: 'edit-profile',
-  //setting/family-settings
-  FAMILY_SETTINGS: 'family-settings',
-  // Q/A
-  QNA: 'qna',
+	// post
+	BASE: '/',
+	HOME: '/home',
+	// Login
+	LOGIN: 'login',
+	// Signup
+	SIGN_UP: 'signup',
+	// Service
+	SERVICE: 'service',
+	// Chat
+	CHAT: 'chat',
+	CHAT_MESSAGE: 'message',
+	// Setting
+	SETTING: 'setting',
+	// Photo
+	PHOTO: 'photo',
+	// Calender
+	CALENDER: 'calender',
+	// Alert
+	ALERT: 'alert',
+	// Family
+	FAMILY: 'family',
+	// setting/family-space-settings
+	FAMILY_SPACE_SETTINGS: 'family-space-settings',
+	// setting/edit-profile
+	EDIT_PROFILE: 'edit-profile',
+	//setting/family-settings
+	FAMILY_SETTINGS: 'family-settings',
+	// Q/A
+	QNA: 'qna',
 };
 
 const API_PATH = {
-  //auth
-  SIGNUP: '/api/v0/auth/signup',
-  LOGIN: '/api/v0/auth/signin',
-  LOGOUT: '/api/v0/auth/signout',
+	//auth
+	SIGNUP: '/api/v0/auth/signup',
+	LOGIN: '/api/v0/auth/signin',
+	LOGOUT: '/api/v0/auth/signout',
 
-  // chat
-  CHAT: '/api/v0/chat-rooms',
+	// chat
+	CHAT: '/api/v0/chat-rooms',
 
-  // family
-  FAMILY: 'api/v0/user-management',
+	// family
+	FAMILY: 'api/v0/user-management',
 
-  // image
-  IMAGE: 'api/v0/s3/presigned',
+	// image
+	IMAGE: 'api/v0/s3/presigned',
 };
 
 export { PAGE_PATH, API_PATH };

--- a/src/layout/home/HomeLayout.jsx
+++ b/src/layout/home/HomeLayout.jsx
@@ -2,23 +2,26 @@ import { Outlet, useLocation } from 'react-router-dom';
 import * as S from './HomeLayout.style';
 import { Sidebar, Settingbar } from '../../components/index';
 import { useEffect, useState } from 'react';
+import { PAGE_PATH } from '../../constants';
 
 const HomeLayout = () => {
-	const location = useLocation();
+	const { pathname } = useLocation();
 	const [isSetting, setIsSetting] = useState(false);
-	const path = location.pathname;
+	const noDisplaySidebar = pathname.startsWith(
+		`${PAGE_PATH.HOME}/${PAGE_PATH.CHAT}/${PAGE_PATH.CHAT_MESSAGE}`,
+	);
 
 	useEffect(() => {
-		if (path.startsWith('/home/setting')) {
+		if (pathname.startsWith(`${PAGE_PATH.HOME}/${PAGE_PATH.SETTING}`)) {
 			setIsSetting(true);
 		} else setIsSetting(false);
-	}, [path]);
+	}, [pathname]);
 
 	return (
 		<S.HomeContainer>
 			<Sidebar />
 			<Settingbar isopen={isSetting} />
-			<S.OutletContainer>
+			<S.OutletContainer $noDisplaySidebar={noDisplaySidebar}>
 				<Outlet />
 			</S.OutletContainer>
 		</S.HomeContainer>

--- a/src/layout/home/HomeLayout.style.js
+++ b/src/layout/home/HomeLayout.style.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import theme from '../../theme/theme';
 
 const HomeContainer = styled.div`
-	height: 100vh;
+	height: 100dvh;
 	width: 100vw;
 	display: flex;
 
@@ -16,7 +16,8 @@ const OutletContainer = styled.div`
 	height: 100%;
 	overflow-y: scroll;
 	@media ${theme.WINDOW_SIZE.MOBILE} {
-		margin-bottom: 80px;
+		margin-bottom: ${({ $noDisplaySidebar }) =>
+			$noDisplaySidebar ? '0' : '80px'};
 	}
 `;
 

--- a/src/pages/chat/message/ChatMessagePage.jsx
+++ b/src/pages/chat/message/ChatMessagePage.jsx
@@ -1,0 +1,5 @@
+const ChatMessagePage = () => {
+	return <>dd</>;
+};
+
+export default ChatMessagePage;

--- a/src/pages/chat/message/ChatMessagePage.jsx
+++ b/src/pages/chat/message/ChatMessagePage.jsx
@@ -1,5 +1,7 @@
+import { Message } from '../../../components';
+
 const ChatMessagePage = () => {
-	return <>dd</>;
+	return <Message />;
 };
 
 export default ChatMessagePage;

--- a/src/pages/chat/message/ChatMessagePage.style.js
+++ b/src/pages/chat/message/ChatMessagePage.style.js
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+import theme from '../../../theme/theme';
+
+const Container = styled.div`
+	width: 100%;
+	height: 100%;
+	background-color: red;
+`;
+
+const NavContainer = styled.div`
+	position: relative;
+	${theme.ALIGN.ROW_SPACE_BETWEEN}
+	padding: 0 50px;
+	width: 100%;
+	height: 75px;
+	border-bottom: 1px solid #cccccc;
+`;
+
+const UserContainer = styled.div`
+	${theme.ALIGN.ROW_CENTER};
+
+	img {
+		width: 42px;
+		height: 42px;
+		border-radius: 50%;
+		object-fit: cover;
+		margin-right: 15px;
+	}
+
+	p {
+		font-size: 20px;
+		font-weight: 700;
+	}
+`;
+export { Container, NavContainer, UserContainer };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,20 +12,22 @@ import FamilySpaceSettings from './setting/FamilySpaceSettings/FamilySpaceSettin
 import EditProfile from './setting/EditProfile/EditProfile';
 import LandingPage from './landing/LadingPage';
 import FamilySettings from './setting/FamilySettings/FamilySettings';
+import ChatMessagePage from './chat/message/ChatMessagePage';
 
 export {
-  MainPage,
-  LoginPage,
-  SignupPage,
-  ChatMainPage,
-  FamilyMainPage,
-  ServiceMainPage,
-  PhotoMainPage,
-  AlertMainPage,
-  CalenderMainPage,
-  LandingPage,
-  QnaPage,
-  FamilySpaceSettings,
-  EditProfile,
-  FamilySettings,
+	MainPage,
+	LoginPage,
+	SignupPage,
+	ChatMainPage,
+	FamilyMainPage,
+	ServiceMainPage,
+	PhotoMainPage,
+	AlertMainPage,
+	CalenderMainPage,
+	LandingPage,
+	QnaPage,
+	FamilySpaceSettings,
+	EditProfile,
+	FamilySettings,
+	ChatMessagePage,
 };


### PR DESCRIPTION
## 🎈 어떤 이슈와 관련된 PR인가요?
>  feature/#95 

## 📝 해당 PR에서 작업한 내용을 설명해주세요.
> 이번 PR은 어떤 작업을 담고 있는지 간략히 설명해주세요!
- [x]  채팅방 반응형 ui 를 위한 페이지 생성 및 ui 구현
- [x]  홈레이아웃 100vh -> 100dvh 로 변경

### 작업 내용과 관련된 스크린샷을 첨부해주세요. (선택 사항)
> 피그마 스크린샷

> 작업 결과 스크린샷
![스크린샷 2024-08-06 01 21 47](https://github.com/user-attachments/assets/049ba3d0-b741-4a28-86ee-25bba574dbdf)
이미지 안보이는건 db변수명이 바뀌어서 다른 브랜치에서 수정했습니다 

## 💬 리뷰어 전달 사항
> 리뷰어가 특별히 알아야 하는 사항을 설명해주세요.

채팅방 한개에 해당하는 api는 없는데 (채팅방하나에 대한 이미지, 제목이 들어간 api 전체 채팅방 조회만있음)
원래는 하나의 페이지였어서 전역상태로 이미지등을 관리했는데 
모바일은 두개의 페이지가 되다보니 새로고침하면 전역상태가 날아가 채팅화면이 안보입니다 .. 
(원래는 한개의 페이지 안에서 컴포넌트만 나눠서 전체를 불러와 클릭한 채팅방 이미지 제목을 메세지에서 넘겨받았습니다
이후 새로고침하더라도 기본을 처음 채팅으로 해놨기 때문에 큰 문제는 없었습니다.)
백엔드 분께 채팅방 한개에 해당하는 api를 요청드려야할지 다른 해결방법이 있는지 고민중입니다.  


!!! 8/6일 19시 기준 
채팅방을 페이지를 나눠서 일단 하는 방식으로 다 수정중이라 
일단은 보류입니다!!!!!!
#105  에서 수정중입니다
